### PR TITLE
Revise link and details for Smithsonian Fellowships

### DIFF
--- a/collections/_opportunities/internship-sifp-serc-2025.md
+++ b/collections/_opportunities/internship-sifp-serc-2025.md
@@ -4,15 +4,12 @@ title: Smithsonian Fellowships
 subtitle: |-
   Smithsonian Environmental Research Center
   {: .mb-1}
-
-  Apply before: 15 October 2024
-  {: .mb-1 .badge .badge-primary}
 description: |-
-  Fellowship opportunities for independent research starting after June 1, 2025. Graduate, predoctoral, postdoctoral, and senior fellowships in biological invasions are available.
+  Fellowship opportunities for independent research. Graduate, predoctoral, postdoctoral, and senior fellowships in biological invasions are periodically available.
 date: 2024-08-30
 deadline: 2024-10-15
 img: assets/img/serc-sifp-2024.jpg
-redirect: https://serc.si.edu/fellowships/opportunities/smithsonian-institution-fellowship-program-at-serc
+redirect: https://serc.si.edu/fellowships/tips-for-applying
 sitemap: false
 importance: 1
 category: training


### PR DESCRIPTION
Removed deadline badge and references to specific availability and updated redirect link to reflect reorganization of internship/fellowship information on SERC website.